### PR TITLE
Dropping URI.escape for Addressable::URI.encode as the former is no longer supported

### DIFF
--- a/lib/isbndb/api_client.rb
+++ b/lib/isbndb/api_client.rb
@@ -11,7 +11,7 @@ module ISBNdb
     end
 
     def request(page, params = {})
-      response = self.class.get(Addressable::URI.parse(page), query: params, headers: headers, timeout: 60)
+      response = self.class.get(Addressable::URI.encode(page), query: params, headers: headers, timeout: 60)
       raise ISBNdb::RequestError.new "HTTP Response: #{response.code}" if response.code != 200
       begin
         self.class.snakify(response.parsed_response)

--- a/lib/isbndb/api_client.rb
+++ b/lib/isbndb/api_client.rb
@@ -11,7 +11,7 @@ module ISBNdb
     end
 
     def request(page, params = {})
-      response = self.class.get(URI.escape(page), query: params, headers: headers, timeout: 60)
+      response = self.class.get(Addressable::URI.parse(page), query: params, headers: headers, timeout: 60)
       raise ISBNdb::RequestError.new "HTTP Response: #{response.code}" if response.code != 200
       begin
         self.class.snakify(response.parsed_response)


### PR DESCRIPTION
Ruby 2.7 deprecated URI.escape and now in Ruby 3.x it's just gone.