### PR TITLE
Fix spec failure

### DIFF
--- a/spec/helpers/webmocks.rb
+++ b/spec/helpers/webmocks.rb
@@ -11,7 +11,7 @@ module Helpers
     endpoint = standard_endpoints(request) || request
     WebMock
       .stub_request(:get, endpoint_to_url(endpoint + query_params))
-      .to_return(body: [], status: status, headers: { 'Content-Type' => 'application/json' })
+      .to_return(body: '', status: status, headers: { 'Content-Type' => 'application/json' })
   end
 
   private


### PR DESCRIPTION
Fix spec failure
```
      Failure/Error: expect{ isbndb_subject.batch('blah error') }.to raise_error(ISBNdb::RequestError)

        expected ISBNdb::RequestError, got #<NoMethodError: undefined method `+@' for []:Array

              @text = +text
                      ^
        Did you mean?  +> with backtrace:
```